### PR TITLE
Divide by zero errors

### DIFF
--- a/lib/Games/Lacuna/Client/Governor.pm
+++ b/lib/Games/Lacuna/Client/Governor.pm
@@ -827,6 +827,10 @@ sub pushes {  # This stage merely analyzes what we have or need.  Actual pushes 
     for my $res (@reslist) {
         my $profile = merge($cfg->{profile}->{$res} || {},$cfg->{profile}->{_default_});
         $self->{push_info}->{$pid}->{$res}->{space_left} = ($status->{"$res\_capacity"} * $profile->{requested_level}) - $status->{"$res\_stored"};
+
+        # if we have no capacity, nothing we can do...
+        next unless $status->{"$res\_capacity"};
+
         if (($status->{"$res\_stored"}/$status->{"$res\_capacity"}) < $profile->{request_below}) {
             my $amt = int($status->{"$res\_capacity"} * $profile->{requested_level}) - $status->{"$res\_stored"};
             $self->{push_info}->{$pid}->{$res}->{requested} = $amt;

--- a/lib/Games/Lacuna/Client/PrettyPrint.pm
+++ b/lib/Games/Lacuna/Client/PrettyPrint.pm
@@ -45,7 +45,7 @@ sub show_status {
             _c_('bold '.($pct_full > 95 ? 'red' : $pct_full > 80 ? 'yellow' : 'green')),
             $res eq 'happiness' ? '  --' : sprintf('%3d%%',$pct_full),
             _c_('cyan'),
-            $res eq 'happiness' ? '    --' : sprintf('% 6.1f',($status->{"$res\_capacity"} - $status->{"$res\_stored"})/$status->{"$res\_hour"}),
+            $res eq 'happiness' ? '    --' : $status->{"$res\_hour"} ? sprintf('% 6.1f',($status->{"$res\_capacity"} - $status->{"$res\_stored"})/$status->{"$res\_hour"}) : '    N/A',
             _c_('reset');
     }
     show_bar('-');


### PR DESCRIPTION
Fix divide by zero errors when rate or capacity is zero (new colonies or Space Stations can have this situation).

This at least partly fixes issue #27
