### PR TITLE
Added tracing to Governor to indicate why an upgrade can't be done

### DIFF
--- a/lib/Games/Lacuna/Client/Governor.pm
+++ b/lib/Games/Lacuna/Client/Governor.pm
@@ -967,6 +967,16 @@ sub attempt_upgrade {
         my $waste_overflow = 
             ($status->{waste_stored} + $self->building_details($pid,$bid)->{upgrade}->{cost}->{waste})
                 > $status->{waste_capacity};
+
+        if ($self->{config}->{verbosity}->{trace}) {
+            my $details = $self->building_details($pid,$bid);
+            if ($insuff_resources) {
+                trace(sprintf("Insufficient resources to upgrade %s, %s (Level %s)",$details->{id},$details->{pretty_type},$details->{level}))
+            }
+            if ($waste_overflow) {
+                trace(sprintf("Too much waste produced to upgrade %s, %s (Level %s)",$details->{id},$details->{pretty_type},$details->{level}))
+            }
+        }
         return (not $insuff_resources and not $waste_overflow)+0;
     } @all_options;
 


### PR DESCRIPTION
I found this useful when trying to work out why my configuration wasn't resulting in any upgrades. Offering it in case it's useful to other people.