### PR TITLE
Change the path from /usr/bin/perl to /usr/bin/env perl

### DIFF
--- a/examples/assemble_halls.pl
+++ b/examples/assemble_halls.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Assemble Halls of Vrbansk recipes, wherever they can be assembled
 #

--- a/examples/available_trades.pl
+++ b/examples/available_trades.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use warnings;
 use FindBin;

--- a/examples/blackhole.pl
+++ b/examples/blackhole.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 use strict;
 use warnings;

--- a/examples/bleeder_report.pl
+++ b/examples/bleeder_report.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/build_plan.pl
+++ b/examples/build_plan.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/build_report.pl
+++ b/examples/build_report.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/build_scheduled.pl
+++ b/examples/build_scheduled.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use warnings;
 use FindBin;

--- a/examples/build_ships.pl
+++ b/examples/build_ships.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use warnings;
 use FindBin;

--- a/examples/capacityplan.pl
+++ b/examples/capacityplan.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use warnings;
 use FindBin;

--- a/examples/close_stars.pl
+++ b/examples/close_stars.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Script to parse thru the probe data and try to
 # find stars that have been missed in probe net

--- a/examples/colony_worlds.pl
+++ b/examples/colony_worlds.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Script to find worlds known to you (via observatories) which are uninhabited, habitable, and in
 # your range of orbits.  Ranks them and presents a summary view.  The scoring algorithm is very

--- a/examples/combine_glyphs.pl
+++ b/examples/combine_glyphs.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/cost_halls_upgrade.pl
+++ b/examples/cost_halls_upgrade.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/cost_resources.pl
+++ b/examples/cost_resources.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/cost_subsidize_build.pl
+++ b/examples/cost_subsidize_build.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/distribution.pl
+++ b/examples/distribution.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Just a proof of concept for distribution center
 

--- a/examples/docked_ships.pl
+++ b/examples/docked_ships.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/fleet.pl
+++ b/examples/fleet.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use warnings;
 use FindBin;

--- a/examples/forward_email.pl
+++ b/examples/forward_email.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # usage:
 # > forward_email.pl /path/to/lacuna.yml /path/to/forward_email.yml

--- a/examples/gene_lab.pl
+++ b/examples/gene_lab.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/get_glyphs.pl
+++ b/examples/get_glyphs.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/glyph_prices.pl
+++ b/examples/glyph_prices.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use warnings;
 

--- a/examples/glyph_report.pl
+++ b/examples/glyph_report.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/glyph_run.pl
+++ b/examples/glyph_run.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/glyphinator.pl
+++ b/examples/glyphinator.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # =================
 #   Glyphinator

--- a/examples/governor.pl
+++ b/examples/governor.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use warnings;
 use FindBin;

--- a/examples/happiness_report.pl
+++ b/examples/happiness_report.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/incoming_ships.pl
+++ b/examples/incoming_ships.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/junk_removal.pl
+++ b/examples/junk_removal.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 ## Junk building trash removal.
 ## Will use the highest available junk building (that is not built) to purge.

--- a/examples/launchpad.pl
+++ b/examples/launchpad.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use warnings;
 use FindBin;

--- a/examples/mail-index.pl
+++ b/examples/mail-index.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/mail-messages.pl
+++ b/examples/mail-messages.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/merge_probe.pl
+++ b/examples/merge_probe.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Script to parse thru the probe data
 #

--- a/examples/mission.pl
+++ b/examples/mission.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use warnings;
 use Getopt::Long qw(GetOptions);

--- a/examples/my_trades.pl
+++ b/examples/my_trades.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/parliament.pl
+++ b/examples/parliament.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/parse_probe.pl
+++ b/examples/parse_probe.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Script to parse thru the probe data
 #

--- a/examples/parse_sift.pl
+++ b/examples/parse_sift.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use warnings;
 use Getopt::Long          (qw(GetOptions));

--- a/examples/parse_star.pl
+++ b/examples/parse_star.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Script to parse thru the probe data
 #

--- a/examples/place_halls.pl
+++ b/examples/place_halls.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/plan_report.pl
+++ b/examples/plan_report.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/plans_report.pl
+++ b/examples/plans_report.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/plant_halls.pl
+++ b/examples/plant_halls.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use warnings;
 use FindBin;

--- a/examples/populate_db.pl
+++ b/examples/populate_db.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # This program populates the database of glyphinator
 # with derived star data.

--- a/examples/probe_js.pl
+++ b/examples/probe_js.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Usage: probes.pl -h
 #  

--- a/examples/prod.pl
+++ b/examples/prod.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use warnings;
 use FindBin;

--- a/examples/production_detail.pl
+++ b/examples/production_detail.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/production_report.pl
+++ b/examples/production_report.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/push.pl
+++ b/examples/push.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/push_all.pl
+++ b/examples/push_all.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/push_glyphs.pl
+++ b/examples/push_glyphs.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/push_plans.pl
+++ b/examples/push_plans.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/push_ships.pl
+++ b/examples/push_ships.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/rearrange_bld.pl
+++ b/examples/rearrange_bld.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 use strict;
 use warnings;

--- a/examples/recall_ships.pl
+++ b/examples/recall_ships.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/rename_ships.pl
+++ b/examples/rename_ships.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/scan_report_summary.pl
+++ b/examples/scan_report_summary.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Grab all scan reports from your inbox and summarize them.
 # Currently outputs text.

--- a/examples/score_bodies.pl
+++ b/examples/score_bodies.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Script to parse thru the probe data and try to
 # score each body and systems by arbritray standards

--- a/examples/send_scows.pl
+++ b/examples/send_scows.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/send_ships.pl
+++ b/examples/send_ships.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/server_details.pl
+++ b/examples/server_details.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/ships_travelling.pl
+++ b/examples/ships_travelling.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 use strict;
 use warnings;

--- a/examples/sift.pl
+++ b/examples/sift.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # For all your plan and glyph sifting needs
 use strict;
 use warnings;

--- a/examples/species_rename.pl
+++ b/examples/species_rename.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # Simple script for renaming species and description
 use strict;
 use warnings;

--- a/examples/spy_run.pl
+++ b/examples/spy_run.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/ss_lab.pl
+++ b/examples/ss_lab.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/star_db_util.pl
+++ b/examples/star_db_util.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # This program manages the star database used by glyphinator
 # It performs the following functions:

--- a/examples/stash_it.pl
+++ b/examples/stash_it.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use warnings;
 use strict;

--- a/examples/storage_inventory.pl
+++ b/examples/storage_inventory.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/theme_park.pl
+++ b/examples/theme_park.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/throw_party.pl
+++ b/examples/throw_party.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/upgrade_nonglyph.pl
+++ b/examples/upgrade_nonglyph.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/examples/upgrade_spaceports.pl
+++ b/examples/upgrade_spaceports.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Simple program for upgrading spaceports.
 

--- a/examples/wastorama2.pl
+++ b/examples/wastorama2.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use warnings;
 use Games::Lacuna::Cache;

--- a/examples/wr.pl
+++ b/examples/wr.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use warnings;
 use 5.010000;


### PR DESCRIPTION
Change to /usr/bin/env in all the example scripts, so that they execute with the user's preferred perl. This is particularly useful on systems where you can't touch the system perl but it is outdated.
